### PR TITLE
ci: build and push container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.gitignore
+.github/
+.vscode/

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,19 +1,28 @@
 name: Build and upload Docker image
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - "*.*.*"
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
-  REGISTRY: ghcr.io
-  BASE_NAME: graphops/indexer-service-rs
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:
-  build-linux:
+  builds-linux:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [indexer-service-rs, indexer-tap-agent]
+
+    permissions:
+      packages: write
 
     steps:
       - name: Checkout
@@ -25,7 +34,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ${{ env.REGISTRY }}/${{ env.BASE_NAME }}
+            ${{ env.REGISTRY }}/${{matrix.target}}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -36,20 +45,18 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}
             type=sha
-            latest:main
-            latest:dev
 
       - name: Log in to the Container registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: ./
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
-          dockerfile: Dockerfile
+          file: Dockerfile.${{ matrix.target }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     container: 
-      image: rust:latest
+      image: rust:1.74-bookworm
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -34,7 +34,7 @@ jobs:
         ports:
           - 5432:5432
     container: 
-      image: rust:latest
+      image: rust:1.74-bookworm
     env:
       DATABASE_URL: postgres://postgres@postgres:5432 
     steps:
@@ -77,7 +77,7 @@ jobs:
         ports:
           - 5432:5432
     container:
-      image: rust:latest
+      image: rust:1.74-bookworm
     env:
       DATABASE_URL: postgres://postgres@postgres:5432 
     steps:

--- a/Dockerfile.indexer-service-rs
+++ b/Dockerfile.indexer-service-rs
@@ -1,0 +1,20 @@
+FROM rust:1.74-bookworm as build
+
+WORKDIR /root
+COPY . .
+
+# Force SQLx to use the offline mode to statically check the database queries against
+# the prepared files in the `.sqlx` directory.
+ENV SQLX_OFFLINE=true
+RUN cargo build --release --bin service
+
+########################################################################################
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /root/target/release/service /usr/local/bin/service
+
+ENTRYPOINT [ "/usr/local/bin/service" ]

--- a/Dockerfile.indexer-tap-agent
+++ b/Dockerfile.indexer-tap-agent
@@ -1,0 +1,20 @@
+FROM rust:1.74-bookworm as build
+
+WORKDIR /root
+COPY . .
+
+# Force SQLx to use the offline mode to statically check the database queries against
+# the prepared files in the `.sqlx` directory.
+ENV SQLX_OFFLINE=true
+RUN cargo build --release --bin indexer-tap-agent
+
+########################################################################################
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /root/target/release/indexer-tap-agent /usr/local/bin/indexer-tap-agent
+
+ENTRYPOINT [ "/usr/local/bin/indexer-tap-agent" ]


### PR DESCRIPTION
For indexer-service-rs and indexer-tap-agent.
Standardized tests and containers around Debian Bookworm. Liberally building and pushing containers for new version tags, pushes to main, and pull requests (to facilitate testing).